### PR TITLE
corrected definition of sigmoid derivative

### DIFF
--- a/machine-learning/mnist/simple/2-Layer-Neural-Network.ipynb
+++ b/machine-learning/mnist/simple/2-Layer-Neural-Network.ipynb
@@ -60,7 +60,7 @@
     "# Define our Sigmoid 'Activation Function'\n",
     "def sigmoid(x,deriv=False):\n",
     "    if(deriv==True):\n",
-    "        return x*(1-x)\n",
+    "        return sigmoid(x)*(1-sigmoid(x))\n",
     "    return 1/(1+np.exp(-x))"
    ]
   },


### PR DESCRIPTION
The derivative of the sigmoid function s(x) is s'(x) = s(x)\*(1-s(x)), not s'(x) = x\*(1-x).